### PR TITLE
Instructions for GlediatorToDisk

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,20 @@ För att avsluta process som körs
 
 ## Filformat ledbarsprogramfil
 Första byten anger antal pixlar i bredd på baren. Andra byten anger antal pixlar i höjd på baren. Därefter följer den pixeldata som ska skickas till baren frame för frame
+
+## Skapa programfil med GlediatorToDisk
+Hämta senaste versionen (GlediatorWithPatchRelease.zip) från https://github.com/HeffU/GlediatorToDisk/releases
+
+Starta Glediator via run_patched.bat (eller .sh, otestat)
+
+Välj File->Load Project och öppna GlediatorToDisk/settings/16x8_8panel_LEDBAR_Project
+
+Säkerställ att pixeladressering är korrekt genom att gå in på Options->Output, klicka på "Patch ArtNet/TMP2.Net", välj Load och filen GlediatorToDisk/settings/16x8_8panel_LEDBAR_ArtNetPatchList
+
+Skapa dina effekter i Glediator, tänk ut ett program och hur du vill byta mellan effekter. Bökigt men fungerande är att använda sliders för att byta mellan de olika kanalerna manuellt. Tips: Börja och avsluta på en liknande och/eller statisk effekt.
+
+När du är nöjd, öppna Options->Output och välj "Open Socket" för att starta inspelning. Stäng Options->Output och utför ditt planerade program. För att avsluta inspelning öppna Options->Output och välj "Close Socket".
+
+Programfilen sparas i GlediatorToDisk/output/ och är döpt efter datum/tid. (Exakt namn kan ses längst ned i Options->Output efter att du tryckt "Close Socket")
+
+Byt eventuellt namn på filen till något passande, och för över den till baren.


### PR DESCRIPTION
Added instructions on how to create a ledbar program-file using GlediatorToDisk.
A bit verbose, but probably needed to make it understandable.